### PR TITLE
Adjust mobile shopping list layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -605,6 +605,7 @@ width: 100%;
     padding: 6px 4px 10px;
     list-style: none;
     display: flex;
+    flex-direction: row;
     flex-wrap: nowrap;
     gap: 10px;
     width: 100%;


### PR DESCRIPTION
## Summary
- ensure the shopping list chips stay in a horizontal row on small screens by forcing a row flex direction

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3f4d5b734833389191eb8b54fb2e2